### PR TITLE
Added "failFast" field to "ChangeLog" annotation. 

### DIFF
--- a/mongock-api/src/main/java/com/github/cloudyrock/mongock/AnnotationProcessor.java
+++ b/mongock-api/src/main/java/com/github/cloudyrock/mongock/AnnotationProcessor.java
@@ -11,6 +11,8 @@ public interface AnnotationProcessor {
   boolean isChangeSetAnnotated(Method method);
 
   String getChangeLogOrder(Class<?> type);
+  
+  boolean getChangeLogFailFast(Class<?> type);
 
   ChangeSetItem getChangeSet(Method method);
 }

--- a/mongock-api/src/main/java/com/github/cloudyrock/mongock/ChangeLog.java
+++ b/mongock-api/src/main/java/com/github/cloudyrock/mongock/ChangeLog.java
@@ -22,4 +22,11 @@ public @interface ChangeLog {
    * @return order
    */
   String order() default "";
+  
+    /**
+   * If true, will make the entire migration to break if the changeLog produce an exception or the validation doesn't
+   * success. Migration will continue otherwise.
+   * @return failFast
+   */
+  boolean failFast() default true;
 }

--- a/mongock-api/src/main/java/com/github/cloudyrock/mongock/ChangeLogItem.java
+++ b/mongock-api/src/main/java/com/github/cloudyrock/mongock/ChangeLogItem.java
@@ -5,18 +5,21 @@ import java.util.Objects;
 
 public class ChangeLogItem {
 
-  private Class<?> type;
+  private final Class<?> type;
 
-  private Object instance;
+  private final Object instance;
 
-  private String order;
+  private final String order;
+  
+  private final boolean failFast;
 
-  private List<ChangeSetItem> changeSetElements;
+  private final List<ChangeSetItem> changeSetElements;
 
-  public ChangeLogItem(Class<?> type, Object instance, String order, List<ChangeSetItem> changeSetElements) {
+  public ChangeLogItem(Class<?> type, Object instance, String order, boolean failFast, List<ChangeSetItem> changeSetElements) {
     this.type = type;
     this.instance = instance;
     this.order = order;
+    this.failFast = failFast;
     this.changeSetElements = changeSetElements;
   }
 
@@ -31,6 +34,10 @@ public class ChangeLogItem {
 
   public String getOrder() {
     return order;
+  }
+  
+  public boolean isFailFast() {
+    return failFast;
   }
 
   public List<ChangeSetItem> getChangeSetElements() {

--- a/mongock-api/src/main/java/com/github/cloudyrock/mongock/MongockAnnotationProcessor.java
+++ b/mongock-api/src/main/java/com/github/cloudyrock/mongock/MongockAnnotationProcessor.java
@@ -20,6 +20,11 @@ public class MongockAnnotationProcessor implements AnnotationProcessor {
   public String getChangeLogOrder(Class<?> type) {
     return type.getAnnotation(ChangeLog.class).order();
   }
+  
+  @Override
+  public boolean getChangeLogFailFast(Class<?> type) {
+    return type.getAnnotation(ChangeLog.class).failFast();
+  }
 
   public ChangeSetItem getChangeSet(Method method) {
     ChangeSet ann = method.getAnnotation(ChangeSet.class);

--- a/mongock-runner/mongock-runner-core/src/main/java/com/github/cloudyrock/mongock/runner/core/executor/ChangeLogService.java
+++ b/mongock-runner/mongock-runner-core/src/main/java/com/github/cloudyrock/mongock/runner/core/executor/ChangeLogService.java
@@ -125,7 +125,7 @@ public class ChangeLogService implements Validable {
 
   private ChangeLogItem buildChangeLogObject(Class<?> type) {
     try {
-      return new ChangeLogItem(type, this.changeLogInstantiator.apply(type), annotationManager.getChangeLogOrder(type), fetchChangeSetFromClass(type));
+      return new ChangeLogItem(type, this.changeLogInstantiator.apply(type), annotationManager.getChangeLogOrder(type), annotationManager.getChangeLogFailFast(type), fetchChangeSetFromClass(type));
     } catch (MongockException ex) {
       throw ex;
     } catch (Exception ex) {

--- a/mongock-runner/mongock-runner-core/src/main/java/com/github/cloudyrock/mongock/runner/core/executor/MigrationExecutor.java
+++ b/mongock-runner/mongock-runner-core/src/main/java/com/github/cloudyrock/mongock/runner/core/executor/MigrationExecutor.java
@@ -92,8 +92,14 @@ public class MigrationExecutor<CHANGE_ENTRY extends ChangeEntry> {
   }
 
   protected void processSingleChangeLog(String executionId, String executionHostname, ChangeLogItem changeLog) {
-    for (ChangeSetItem changeSet : changeLog.getChangeSetElements()) {
-      executeInTransactionIfStrategyOrUsualIfNot(TransactionStrategy.CHANGE_SET, () -> processSingleChangeSet(executionId, executionHostname, changeLog, changeSet));
+    try {
+      for (ChangeSetItem changeSet : changeLog.getChangeSetElements()) {
+        executeInTransactionIfStrategyOrUsualIfNot(TransactionStrategy.CHANGE_SET, () -> processSingleChangeSet(executionId, executionHostname, changeLog, changeSet));
+      }
+    } catch (Exception e) {
+      if (changeLog.isFailFast()) {
+        throw e;
+      }
     }
   }
 

--- a/mongock-runner/mongock-runner-core/src/test/java/com/github/cloudyrock/mongock/runner/core/changelogs/executor/test5_with_changelognonfailfast/ExecutorWithChangeLogNonFailFastChangeLog1.java
+++ b/mongock-runner/mongock-runner-core/src/test/java/com/github/cloudyrock/mongock/runner/core/changelogs/executor/test5_with_changelognonfailfast/ExecutorWithChangeLogNonFailFastChangeLog1.java
@@ -1,0 +1,29 @@
+package com.github.cloudyrock.mongock.runner.core.changelogs.executor.test5_with_changelognonfailfast;
+
+import com.github.cloudyrock.mongock.ChangeLog;
+import com.github.cloudyrock.mongock.ChangeSet;
+import com.github.cloudyrock.mongock.runner.core.util.DummyDependencyClass;
+
+import java.util.concurrent.CountDownLatch;
+
+@ChangeLog(order = "1", failFast = false)
+public class ExecutorWithChangeLogNonFailFastChangeLog1 {
+
+  public final static CountDownLatch latch = new CountDownLatch(2);
+
+  @ChangeSet(author = "executor", id = "newChangeSet11", order = "1")
+  public void newChangeSet11(DummyDependencyClass dependency) {
+    latch.countDown();
+  }
+
+  @ChangeSet(author = "executor", id = "newChangeSet12", order = "2")
+  public void newChangeSet12(DummyDependencyClass dependency) {
+    latch.countDown();
+    throw new RuntimeException("This method throws an exception");
+  }
+
+  @ChangeSet(author = "executor", id = "newChangeSet13", order = "3")
+  public void newChangeSet13(DummyDependencyClass dependency) {
+    throw new RuntimeException("This method should not be executed");
+  }
+}

--- a/mongock-runner/mongock-runner-core/src/test/java/com/github/cloudyrock/mongock/runner/core/changelogs/executor/test5_with_changelognonfailfast/ExecutorWithChangeLogNonFailFastChangeLog2.java
+++ b/mongock-runner/mongock-runner-core/src/test/java/com/github/cloudyrock/mongock/runner/core/changelogs/executor/test5_with_changelognonfailfast/ExecutorWithChangeLogNonFailFastChangeLog2.java
@@ -1,0 +1,22 @@
+package com.github.cloudyrock.mongock.runner.core.changelogs.executor.test5_with_changelognonfailfast;
+
+import com.github.cloudyrock.mongock.ChangeLog;
+import com.github.cloudyrock.mongock.ChangeSet;
+import com.github.cloudyrock.mongock.runner.core.util.DummyDependencyClass;
+import java.util.concurrent.CountDownLatch;
+
+@ChangeLog(order = "2")
+public class ExecutorWithChangeLogNonFailFastChangeLog2 {
+  
+  public final static CountDownLatch latch = new CountDownLatch(2);
+
+  @ChangeSet(author = "executor", id = "newChangeSet21", order = "1")
+  public void newChangeSet21(DummyDependencyClass dependency) {
+    latch.countDown();
+  }
+ 
+  @ChangeSet(author = "executor", id = "newChangeSet22", order = "2")
+  public void newChangeSet22(DummyDependencyClass dependency) {
+    latch.countDown();
+  }
+}

--- a/mongock-runner/mongock-runner-core/src/test/java/com/github/cloudyrock/mongock/runner/core/changelogs/executor/test6_with_changelogfailfast/ExecutorWithChangeLogFailFastChangeLog1.java
+++ b/mongock-runner/mongock-runner-core/src/test/java/com/github/cloudyrock/mongock/runner/core/changelogs/executor/test6_with_changelogfailfast/ExecutorWithChangeLogFailFastChangeLog1.java
@@ -1,0 +1,29 @@
+package com.github.cloudyrock.mongock.runner.core.changelogs.executor.test6_with_changelogfailfast;
+
+import com.github.cloudyrock.mongock.ChangeLog;
+import com.github.cloudyrock.mongock.ChangeSet;
+import com.github.cloudyrock.mongock.runner.core.util.DummyDependencyClass;
+
+import java.util.concurrent.CountDownLatch;
+
+@ChangeLog(order = "1", failFast = true)
+public class ExecutorWithChangeLogFailFastChangeLog1 {
+
+  public final static CountDownLatch latch = new CountDownLatch(2);
+
+  @ChangeSet(author = "executor", id = "newChangeSet11", order = "1")
+  public void newChangeSet11(DummyDependencyClass dependency) {
+    latch.countDown();
+  }
+
+  @ChangeSet(author = "executor", id = "newChangeSet12", order = "2")
+  public void newChangeSet12(DummyDependencyClass dependency) {
+    latch.countDown();
+    throw new RuntimeException("This method throws an exception");
+  }
+
+  @ChangeSet(author = "executor", id = "newChangeSet13", order = "3")
+  public void newChangeSet13(DummyDependencyClass dependency) {
+    throw new RuntimeException("This method should not be executed");
+  }
+}

--- a/mongock-runner/mongock-runner-core/src/test/java/com/github/cloudyrock/mongock/runner/core/changelogs/executor/test6_with_changelogfailfast/ExecutorWithChangeLogFailFastChangeLog2.java
+++ b/mongock-runner/mongock-runner-core/src/test/java/com/github/cloudyrock/mongock/runner/core/changelogs/executor/test6_with_changelogfailfast/ExecutorWithChangeLogFailFastChangeLog2.java
@@ -1,0 +1,19 @@
+package com.github.cloudyrock.mongock.runner.core.changelogs.executor.test6_with_changelogfailfast;
+
+import com.github.cloudyrock.mongock.ChangeLog;
+import com.github.cloudyrock.mongock.ChangeSet;
+import com.github.cloudyrock.mongock.runner.core.util.DummyDependencyClass;
+
+@ChangeLog(order = "2")
+public class ExecutorWithChangeLogFailFastChangeLog2 {
+
+  @ChangeSet(author = "executor", id = "newChangeSet21", order = "1")
+  public void newChangeSet21(DummyDependencyClass dependency) {
+    throw new RuntimeException("This method should not be executed");
+  }
+ 
+  @ChangeSet(author = "executor", id = "newChangeSet22", order = "2")
+  public void newChangeSet22(DummyDependencyClass dependency) {
+    throw new RuntimeException("This method should not be executed");
+  }
+}


### PR DESCRIPTION
If it's true (default value), migration will abort when any changeSet (child) fails. Otherwise, migration will only abort current changeLog and continue with the next one.